### PR TITLE
Fix typo for "Group" for query and store subscriptions

### DIFF
--- a/pubSub/pubSub.js
+++ b/pubSub/pubSub.js
@@ -75,7 +75,7 @@ class PubSub{
         }
 
         if(this.group !== undefined){
-            subRequest.group = this.group;
+            subRequest.Group = this.group;
         }
        
 

--- a/rpc/query/queryReceiver.js
+++ b/rpc/query/queryReceiver.js
@@ -57,7 +57,7 @@ class QueryReceiver{
      * @param {error_handler} error_handler - Callback for incoming errors.
      */
     subscribe(req_handler, error_handler) {
-        this.rpc.subscribe(req_handler, req_handler);
+        this.rpc.subscribe(req_handler, error_handler);
     }
 
     /**


### PR DESCRIPTION
Fix typo for "Group" for query and store subscriptions.
Pass correct error handler